### PR TITLE
fix(drawer): scrollbar bug

### DIFF
--- a/Frontend/src/LeftDrawer/FilterCheckbox.js
+++ b/Frontend/src/LeftDrawer/FilterCheckbox.js
@@ -37,7 +37,8 @@ function FilterCheckbox(props) {
     return(
         <FormControlLabel control={<Checkbox/>}
         label={props.text}
-        sx={{ width: 1 }} // Future: Change with screen width
+        componentsProps={{ typography: {fontSize: {'xs': 40, 'md': 25}}}}
+        sx = {{ width: 0.98 }} // ensures that one item takes up one row
         onChange={(event) => handleChange(props, event)}/>
     );
 };


### PR DESCRIPTION
See issue #57 for details; reduced width of FilterCheckbox component, now assuming the text of a tag does not overflow the provided space, horizontal scroll bar will not appear.
Closes #57