### PR TITLE
fix(drawer): Not A Function Error

### DIFF
--- a/Frontend/src/LeftDrawer/LeftDrawer.js
+++ b/Frontend/src/LeftDrawer/LeftDrawer.js
@@ -47,12 +47,12 @@ function LeftDrawer(props) {
     const drawerWidth = 240; // Future: Variable based on screen size?
 
     const handleDrawerClose = () => {
-        setIsClosing(true);
-        setMobileOpen(false);
+        setIsClosingDrawer(true);
+        setDrawerOpen(false);
     };
 
     const handleDrawerTransitionEnd = () => {
-        props.setIsClosing(false);
+        props.setIsClosingDrawer(false);
     };
     
     return (

--- a/Frontend/src/TopAppBar/TopAppBar.js
+++ b/Frontend/src/TopAppBar/TopAppBar.js
@@ -28,7 +28,6 @@ function TopAppBar(props) {
 
     const handleDrawerToggle = () => {
         if (!props.isClosingDrawer) {
-            console.log("setting props.drawerOpen to: " + !props.drawerOpen);
             props.setDrawerOpen(!props.drawerOpen);
         };
     };


### PR DESCRIPTION
LeftDrawer was generating a "not a function" error because certain props/functions were typoed.  Fixed this.