### PR TITLE
feat(ImageList):  Reverse Order

### DIFF
--- a/Frontend/src/VirtualizedImageList.js
+++ b/Frontend/src/VirtualizedImageList.js
@@ -97,7 +97,10 @@ export default function VirtuosoGridWrapper (props) {
           components={gridComponents}
           itemContent={(index) => 
             <ItemWrapper>
-              <Thumbnail src={imageList[index].source} id={imageList[index].id}/>
+              <Thumbnail
+                // Provide images in reverse order -- (length - index)
+                src={imageList[(imageList.length-1)-index].source}
+                id={imageList[(imageList.length-1)-index].id}/>
             </ItemWrapper>
           }
         />


### PR DESCRIPTION
Reversing the image order shows newly uploaded images at the top, which is preferable for a meme cataloger (and possibly all photo organizers as a default).  We love recency bias.