### PR TITLE
refac(App.js): undo misguided changes

### DIFF
--- a/Frontend/src/MainPage/App.js
+++ b/Frontend/src/MainPage/App.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Box, createTheme, CssBaseline, Toolbar } from '@mui/material';
 import { ThemeProvider } from '@emotion/react';
 
+import ApiCall from '../SupportingModules/ApiCall';
 import TopAppBar from './TopAppBar';
 import TagDrawer from './TagDrawer/TagDrawer';
 import VirtuosoGridWrapper from './ImageList/VirtualizedImageList';
@@ -11,39 +12,8 @@ import DropHandler from './Uploads/DropHandler';
 import UploadFilesContextProvider from './Uploads/UploadFilesContext';
 
 
-export function AppChildren() {
-  return (
-      <Box sx={{ display: 'flex' }}>
-          {/* Provided by MUI Material for basic styling */}
-          <CssBaseline />
-
-          {/* Navigation banner/AppBar at top of the page */}
-          <TopAppBar/>
-
-          {/* Drawer on left side, holds tag filter options */}
-          <TagDrawer/>
-
-          {/* Main content area */}
-          <Box component="main" sx={{ flexGrow: 1 }}>
-              <Toolbar />{/* Hides under AppBar, push below to open space */}
-              <div className='flex-container'>
-                  <VirtuosoGridWrapper/>
-              </div>
-          </Box>
-      </Box>
-  );
-
-}
-
-export function AppContents() {
-  return(
-    <UploadFilesContextProvider>
-      <DropHandler>
-        <ContentFrame />
-      </DropHandler>
-    </UploadFilesContextProvider>
-  );
-};
+// initial data for page load, provided by Django API.
+let apiData = await ApiCall();
 
 /**
  * Root component that renders all other components.
@@ -51,19 +21,17 @@ export function AppContents() {
  * which is the hub for WebSocket communications with backend.
  * 
  * @param {object} props Contains props passed into the component.
- * @param {Array} props.apiData Data for initial page load.
  * 
  * @returns The root App component to render all other components.
  */
 export default function App(props) {
-
   // useFilterSocket receives messages for updates to appData.
   // appData contains Image, Tag and ImageTag data.
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [isClosingDrawer, setIsClosingDrawer] = useState(false);
   const [editTags, setEditTags] = useState(false);
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
-  const appData = useFilterSocket(props.apiData);
+  const appData = useFilterSocket(apiData);
   const appState = {
     drawerOpen: drawerOpen,
     setDrawerOpen: setDrawerOpen,
@@ -103,7 +71,24 @@ export default function App(props) {
       <AppDataContext.Provider value={{appData, appState}}>
       <UploadFilesContextProvider>
         <DropHandler>
-          {props.children}
+          <Box sx={{ display: 'flex' }}>
+            {/* Provided by MUI Material for basic styling */}
+            <CssBaseline />
+
+            {/* Navigation banner/AppBar at top of the page */}
+            <TopAppBar/>
+
+            {/* Drawer on left side, holds tag filter options */}
+            <TagDrawer/>
+
+            {/* Main content area */}
+            <Box component="main" sx={{ flexGrow: 1 }}>
+                <Toolbar />{/* Hides under AppBar, push below to open space */}
+                <div className='flex-container'>
+                    <VirtuosoGridWrapper/>
+                </div>
+            </Box>
+          </Box>
         </DropHandler>
       </UploadFilesContextProvider>
       </AppDataContext.Provider>

--- a/Frontend/src/MainPage/index.js
+++ b/Frontend/src/MainPage/index.js
@@ -1,12 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
-import ApiCall from '../SupportingModules/ApiCall';
-import App, { AppChildren } from './App';
+import App from './App';
 
-
-// initial data for page load, provided by Django API.
-let apiData = await ApiCall();
 
 // HTML root for the app, as required by React.
 const root = ReactDOM.createRoot(document.getElementById('root'));
@@ -15,8 +11,6 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   // StrictMode renders everything twice to help catch bugs.
   <React.StrictMode>
-    <App apiData={apiData}>
-      <AppChildren/>
-    </App>
+    <App/>
   </React.StrictMode>
 );


### PR DESCRIPTION
Previously, App had been gutted in the name of testing.  Having learned how to use Jest mocks, this wasn't necessasry.  Undoing this change to keep things (relatively) clean and sane as they were before.

Moved the ApiCall to App as well, which is more appropriate than in index.js.  (index should be as minimal as possible, content should start with App.js)