### PR TITLE
Grey out filters

### DIFF
--- a/Frontend/src/MainPage/App.js
+++ b/Frontend/src/MainPage/App.js
@@ -29,17 +29,19 @@ export default function App() {
   // appData contains Image, Tag and ImageTag data.
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [isClosingDrawer, setIsClosingDrawer] = useState(false);
+  const [noMatchFilters, setNoMatchFilters] = useState([]);
   const [editTags, setEditTags] = useState(false);
   const [files, setFiles] = useState([]);
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
   const [selectionActive, setSelectionActive] = useState(false);
   const [selectedItems, setSelectedItems] = useState([]);
-  const appData = useFilterSocket(apiData);
   const appState = {
     drawerOpen: drawerOpen,
     setDrawerOpen: setDrawerOpen,
     isClosingDrawer: isClosingDrawer,
     setIsClosingDrawer: setIsClosingDrawer,
+    noMatchFilters: noMatchFilters,
+    setNoMatchFilters: setNoMatchFilters,
     editTags: editTags,
     setEditTags: setEditTags,
     files: files,
@@ -51,6 +53,7 @@ export default function App() {
     selectedItems: selectedItems,
     setSelectedItems: setSelectedItems
   };
+  const appData = useFilterSocket(apiData, appState);
   // createTheme sets background color
   const theme = createTheme({
     palette: {

--- a/Frontend/src/MainPage/TagDrawer/FilterCheckbox.js
+++ b/Frontend/src/MainPage/TagDrawer/FilterCheckbox.js
@@ -29,6 +29,7 @@ const handleChange = (props, event) => {
  * @param {object} props Contains props passed to the component.
  * @param {string} props.text String label of the checkbox; matches name of tag to filter.
  * @param {number} props.tagId The numerical tag ID to filter for when this box is checked.
+ * @param {Array} props.noMatchFilters greys out label on no results
  * @returns The FilterCheckbox component to be rendered in the app.
  */
 function FilterCheckbox(props) {
@@ -36,12 +37,17 @@ function FilterCheckbox(props) {
     const largeScreen = useMediaQuery(theme.breakpoints.up('md'));
     const largeScreenStyle = {transform: "scale(1.15)", margin: "0 0 0 3%"};
     const smallScreenStyle = {transform: "scale(1.75)", margin: "0 1% 0 2.5%"};
+    const greyedOut = props.noMatchFilters.includes(props.tagId);
+    const labelStyles = {
+        width: 0.98, // ensures that one item takes up one row
+        color: greyedOut ? 'rgba(20, 20, 20, 0.6)' : 'rgba(0, 0, 0, 0.87)'
+    };
 
     return(
         <FormControlLabel control={<Checkbox style={ largeScreen ? largeScreenStyle : smallScreenStyle }/>}
         label={props.text}
         componentsProps={{ typography: {fontSize: {'xs': 40, 'md': 25}}}}
-        sx = {{ width: 0.98 }} // ensures that one item takes up one row
+        sx = {labelStyles}
         onChange={(event) => handleChange(props, event)}/>
     );
 };

--- a/Frontend/src/MainPage/TagDrawer/FilterCheckbox.test.js
+++ b/Frontend/src/MainPage/TagDrawer/FilterCheckbox.test.js
@@ -20,7 +20,14 @@ describe('FilterSocket', () => {
     beforeEach(() => {
         tagName = 'Test Tag';
         tagId = '1';
-        render(<FilterCheckbox text={tagName} tagId={tagId} key={tagId}/>);
+        render(
+            <FilterCheckbox
+                text={tagName}
+                tagId={tagId}
+                key={tagId}
+                noMatchFilters={[]}
+            />
+        );
     });
 
     test('toggles checked and unchecked', () => {

--- a/Frontend/src/MainPage/TagDrawer/TagDrawer.js
+++ b/Frontend/src/MainPage/TagDrawer/TagDrawer.js
@@ -85,7 +85,8 @@ export default function TagDrawer() {
                                 <FilterCheckbox
                                 text={tagName}
                                 key={tagId}
-                                tagId={tagId}/>
+                                tagId={tagId}
+                                noMatchFilters={appState.noMatchFilters}/>
                             )
                         }))}
                 </List>

--- a/Frontend/src/MainPage/TagDrawer/TagDrawer.test.js
+++ b/Frontend/src/MainPage/TagDrawer/TagDrawer.test.js
@@ -22,7 +22,10 @@ describe('TagDrawer', () => {
             ],
             imageTagData: [] // not used in this component
         };
-        appState = {drawerOpen: true}; // visible by default
+        appState = {
+            drawerOpen: true, // visible by default
+            noMatchFilters: []
+        }; 
 
         // jsdom does not have window.matchMedia;
         // it must be mocked for testing screen-responsive components.
@@ -85,7 +88,7 @@ describe('TagDrawer', () => {
         });
         window.dispatchEvent(new Event('resize'));
 
-        appState = {drawerOpen: false};
+        appState = {...appState, drawerOpen: false};
         const {rerender} = render(
             <AppDataContext.Provider value={{appData, appState}}>
                 <TagDrawer/>
@@ -94,7 +97,7 @@ describe('TagDrawer', () => {
         expect(screen.getByTestId('temporary-drawer'))
             .toHaveClass('MuiModal-hidden');
 
-        appState = {drawerOpen: true};
+        appState = {...appState, drawerOpen: true};
         rerender(
             <AppDataContext.Provider value={{appData, appState}}>
                 <TagDrawer/>

--- a/Sockets/consumers.py
+++ b/Sockets/consumers.py
@@ -139,7 +139,6 @@ class FilterConsumer(WebsocketConsumer):
             for tag in tags_list:
                 if tag.id not in associated_tags:
                     associated_tags.append(tag.id)
-                    print(f"Added {tag.id}!")
 
         for result in image_queryset:
             image_results.append(result.id)

--- a/Sockets/tests.py
+++ b/Sockets/tests.py
@@ -67,61 +67,61 @@ class TestApplyFilters(TestSocketConsumer):
         # Should return 1
         text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [1]}
         image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['results'], [1])
+        self.assertEqual(image_result_data['imageResults'], [1])
 
     def test_typical_case_2(self):
         # Should return 1 and 2
         text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [2]}
         image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['results'], [1, 2])
+        self.assertEqual(image_result_data['imageResults'], [1, 2])
 
     def test_typical_case_3(self):
         # Should return 1 and 3
         text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [3]}
         image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['results'], [1, 3])
+        self.assertEqual(image_result_data['imageResults'], [1, 3])
 
     def test_typical_case_4(self):
         # Should return 2
         text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [4]}
         image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['results'], [2])
+        self.assertEqual(image_result_data['imageResults'], [2])
 
     def test_typical_case_5(self):
         # Should return 1
         text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [5]}
         image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['results'], [1])
+        self.assertEqual(image_result_data['imageResults'], [1])
 
     def test_typical_case_6(self):
         # Should return 2 and 3
         text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [6]}
         image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['results'], [2, 3])
+        self.assertEqual(image_result_data['imageResults'], [2, 3])
 
     def test_typical_case_7(self):
         # Should return 1
         text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [7]}
         image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['results'], [1])
+        self.assertEqual(image_result_data['imageResults'], [1])
 
     def test_typical_case_8(self):
         # Should return 2
         text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [8]}
         image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['results'], [2])
+        self.assertEqual(image_result_data['imageResults'], [2])
 
     def test_typical_case_9(self):
         # Should return 3
         text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [9]}
         image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['results'], [3])
+        self.assertEqual(image_result_data['imageResults'], [3])
 
     def test_typical_case_10(self):
         # Should return none
         text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [10]}
         image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['results'], [])
+        self.assertEqual(image_result_data['imageResults'], [])
 
 
 class TestAddTag(TestSocketConsumer):


### PR DESCRIPTION
When selecting a new filter, any filter that would return zero results when added to the existing filter(s) is greyed out to indicate a lack of results without needing to manually check.  Makes searching by tags just that much easier!

Addresses #61 