### PR TITLE
Exact match filter

### DIFF
--- a/Frontend/src/MainPage/App.js
+++ b/Frontend/src/MainPage/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Box, createTheme, CssBaseline, Toolbar } from '@mui/material';
 import { ThemeProvider } from '@emotion/react';
 
@@ -29,7 +29,9 @@ export default function App() {
   // appData contains Image, Tag and ImageTag data.
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [isClosingDrawer, setIsClosingDrawer] = useState(false);
+  const [activeFilters, setActiveFilters] = useState([]);
   const [noMatchFilters, setNoMatchFilters] = useState([]);
+  const exactMatchFilters = useRef(false);
   const [editTags, setEditTags] = useState(false);
   const [files, setFiles] = useState([]);
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
@@ -40,8 +42,11 @@ export default function App() {
     setDrawerOpen: setDrawerOpen,
     isClosingDrawer: isClosingDrawer,
     setIsClosingDrawer: setIsClosingDrawer,
+    activeFilters: activeFilters,
+    setActiveFilters: setActiveFilters,
     noMatchFilters: noMatchFilters,
     setNoMatchFilters: setNoMatchFilters,
+    exactMatchFilters: exactMatchFilters,
     editTags: editTags,
     setEditTags: setEditTags,
     files: files,

--- a/Frontend/src/MainPage/TagDrawer/ExactMatchSwitch.js
+++ b/Frontend/src/MainPage/TagDrawer/ExactMatchSwitch.js
@@ -1,0 +1,47 @@
+import React, { useContext, useEffect, useRef } from 'react';
+
+import AppDataContext from '../../SupportingModules/AppDataContext';
+import filterSocket from '../../SupportingModules/FilterSocket';
+
+
+export default function ExactMatchSwitch() {
+  const { appState } = useContext(AppDataContext);
+  const inputRef = useRef(null);
+
+  const handleChange = () => {
+    appState.exactMatchFilters.current = !appState.exactMatchFilters.current
+    filterSocket.send(JSON.stringify({
+      'type': 'activeFilters',
+      'exactMatch': appState.exactMatchFilters.current,
+      'activeFilters': appState.activeFilters,
+      'origin': 'ExactMatchSwitch.js'
+    }));
+  };
+
+  const handleLabelClick = () => {
+    if (inputRef.current.checked) {
+      inputRef.current.checked = false;
+    } else {
+      inputRef.current.checked = true;
+    };
+    handleChange(); // Yo JS, kinda stupid that I gotta do this
+  };
+
+  return(
+    <>
+      <label
+        htmlFor='exactMatchCheckbox'
+        onClick={handleLabelClick}
+        style={{'fontSize': '20px'}}
+      >
+        Exact Match
+      </label>
+      <input
+        name='exactMatchCheckbox'
+        type='checkbox'
+        onChange={handleChange}
+        ref={inputRef}
+      />
+    </>
+  );
+};

--- a/Frontend/src/MainPage/TagDrawer/ExactMatchSwitch.js
+++ b/Frontend/src/MainPage/TagDrawer/ExactMatchSwitch.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { useContext, useRef } from 'react';
 
 import AppDataContext from '../../SupportingModules/AppDataContext';
 import filterSocket from '../../SupportingModules/FilterSocket';

--- a/Frontend/src/MainPage/TagDrawer/TagDrawer.js
+++ b/Frontend/src/MainPage/TagDrawer/TagDrawer.js
@@ -10,6 +10,7 @@ import FilterCheckbox from './FilterCheckbox';
 import TagEditor from './TagEditor';
 import FeatureButton from './FeatureButton';
 import DrawerHeader from './DrawerHeader';
+import ExactMatchSwitch from './ExactMatchSwitch';
 
 
 /**
@@ -70,6 +71,7 @@ export default function TagDrawer() {
             <Toolbar/>
             <Box sx={{ overflow: 'auto' }}>
                 <DrawerHeader handleEdit={handleEdit}/>
+                <ExactMatchSwitch />
                 <List> {/* List tags available for filtering */}
                         {(appData.tagData.map((tag) => {
                             const tagId = tag.id;

--- a/Frontend/src/MainPage/TagDrawer/TagDrawer.test.js
+++ b/Frontend/src/MainPage/TagDrawer/TagDrawer.test.js
@@ -114,8 +114,10 @@ describe('TagDrawer', () => {
             </AppDataContext.Provider>
         );
 
+        // This will include "exact match" checkbox
         const checkboxes = screen.getAllByRole('checkbox');
-        expect(checkboxes.length).toEqual(appData.tagData.length);
+        // Check for all test filters plus "exact match" checkbox
+        expect(checkboxes.length).toEqual(appData.tagData.length+1);
     });
 
     test('correctly renders TagEditor components on large screen', () => {
@@ -152,9 +154,11 @@ describe('TagDrawer', () => {
                 <TagDrawer/>
             </AppDataContext.Provider>
         );
-
+        
+        // This will include "exact match" checkbox
         const checkboxes = screen.getAllByRole('checkbox');
-        expect(checkboxes.length).toEqual(appData.tagData.length);
+        // Check for all test filters plus "exact match" checkbox
+        expect(checkboxes.length).toEqual(appData.tagData.length+1);
     });
 
     test('correctly renders TagEditor components on small screen', () => {

--- a/Sockets/consumers.py
+++ b/Sockets/consumers.py
@@ -101,7 +101,40 @@ class FilterConsumer(WebsocketConsumer):
         pass
 
     @staticmethod
-    def apply_filters(text_data_json: dict) -> dict:
+    def filter_exact(active_filters, image_query) -> QuerySet:
+        if not active_filters:
+            imagetags = ImageTag.objects.all()
+            images_with_tags = [
+                i.image_id for i in imagetags
+            ]
+            image_query = Image.objects.all()
+            for image in images_with_tags:
+                image_query = image_query.exclude(id=image.id)
+            return(image_query)
+    
+        for image in image_query:
+            tags = set(
+                i.tag_id.id for i in ImageTag.objects.filter(image_id=image)
+            )
+            if tags != set(active_filters):
+                image_query = image_query.exclude(id=image.id)
+        return(image_query)
+
+    @staticmethod
+    def grey_out_filters(image_query) -> list:
+        associated_tags: list = []
+
+        for image in image_query:
+            # collect tag IDs associated with image
+            imagetags_query:QuerySet=ImageTag.objects.filter(image_id=image.id)
+            tags_list: list=[image_tag.tag_id for image_tag in imagetags_query]
+            # if tag IDs are not in list, append them
+            for tag in tags_list:
+                if tag.id not in associated_tags:
+                    associated_tags.append(tag.id)
+        return associated_tags
+    
+    def apply_filters(self, text_data_json: dict) -> dict:
         """Queries DB for objects matching filter array, and passes this list back to the client.
 
         Parameters
@@ -126,21 +159,18 @@ class FilterConsumer(WebsocketConsumer):
         """
 
         active_filters: list = text_data_json['activeFilters']
-        image_queryset: QuerySet = Image.objects.all()
+        exact_match: bool = text_data_json['exactMatch']
+        image_query: QuerySet = Image.objects.all()
         image_results: list = []
-        associated_tags: list = []  # tags on images in image_results
         for f in active_filters:
-            image_queryset = image_queryset.filter(imagetag__tag_id=f)
-        for image in image_queryset:
-            # collect tag IDs associated with image
-            imagetags_query: QuerySet = ImageTag.objects.filter(image_id=image.id)
-            tags_list: list = [image_tag.tag_id for image_tag in imagetags_query]
-            # if tag IDs are not in list, append them
-            for tag in tags_list:
-                if tag.id not in associated_tags:
-                    associated_tags.append(tag.id)
+            image_query = image_query.filter(imagetag__tag_id__exact=f)
+        associated_tags: list = self.grey_out_filters(image_query)
+        print(associated_tags)
+        if exact_match:
+            image_query = self.filter_exact(active_filters, image_query)
+        
 
-        for result in image_queryset:
+        for result in image_query:
             image_results.append(result.id)
 
         response_message: dict = {

--- a/Sockets/consumers.py
+++ b/Sockets/consumers.py
@@ -165,10 +165,8 @@ class FilterConsumer(WebsocketConsumer):
         for f in active_filters:
             image_query = image_query.filter(imagetag__tag_id__exact=f)
         associated_tags: list = self.grey_out_filters(image_query)
-        print(associated_tags)
         if exact_match:
             image_query = self.filter_exact(active_filters, image_query)
-        
 
         for result in image_query:
             image_results.append(result.id)

--- a/Sockets/tests.py
+++ b/Sockets/tests.py
@@ -65,63 +65,103 @@ class TestApplyFilters(TestSocketConsumer):
 
     def test_typical_case_1(self):
         # Should return 1
-        text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [1]}
-        image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['imageResults'], [1])
+        text_data_1: dict = {
+            'type': 'activeFilters',
+            'activeFilters': [1],
+            'exactMatch': False
+        }
+        result: dict = FilterConsumer().apply_filters(text_data_1)
+        self.assertEqual(result['imageResults'], [1])
 
     def test_typical_case_2(self):
         # Should return 1 and 2
-        text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [2]}
-        image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['imageResults'], [1, 2])
+        text_data_2: dict = {
+            'type': 'activeFilters',
+            'activeFilters': [2],
+            'exactMatch': False
+        }
+        result: dict = FilterConsumer().apply_filters(text_data_2)
+        self.assertEqual(result['imageResults'], [1, 2])
 
     def test_typical_case_3(self):
         # Should return 1 and 3
-        text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [3]}
-        image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['imageResults'], [1, 3])
+        text_data_3: dict = {
+            'type': 'activeFilters',
+            'activeFilters': [3],
+            'exactMatch': False
+        }
+        result: dict = FilterConsumer().apply_filters(text_data_3)
+        self.assertEqual(result['imageResults'], [1, 3])
 
     def test_typical_case_4(self):
         # Should return 2
-        text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [4]}
-        image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['imageResults'], [2])
+        text_data_4: dict = {
+            'type': 'activeFilters',
+            'activeFilters': [4],
+            'exactMatch': False
+        }
+        result: dict = FilterConsumer().apply_filters(text_data_4)
+        self.assertEqual(result['imageResults'], [2])
 
     def test_typical_case_5(self):
         # Should return 1
-        text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [5]}
-        image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['imageResults'], [1])
+        text_data_5: dict = {
+            'type': 'activeFilters',
+            'activeFilters': [5],
+            'exactMatch': False
+        }
+        result: dict = FilterConsumer().apply_filters(text_data_5)
+        self.assertEqual(result['imageResults'], [1])
 
     def test_typical_case_6(self):
         # Should return 2 and 3
-        text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [6]}
-        image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['imageResults'], [2, 3])
+        text_data_6: dict = {
+            'type': 'activeFilters',
+            'activeFilters': [6],
+            'exactMatch': False
+        }
+        result: dict = FilterConsumer().apply_filters(text_data_6)
+        self.assertEqual(result['imageResults'], [2, 3])
 
     def test_typical_case_7(self):
         # Should return 1
-        text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [7]}
-        image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['imageResults'], [1])
+        text_data_7: dict = {
+            'type': 'activeFilters',
+            'activeFilters': [7],
+            'exactMatch': False
+        }
+        result: dict = FilterConsumer().apply_filters(text_data_7)
+        self.assertEqual(result['imageResults'], [1])
 
     def test_typical_case_8(self):
         # Should return 2
-        text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [8]}
-        image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['imageResults'], [2])
+        text_data_8: dict = {
+            'type': 'activeFilters',
+            'activeFilters': [8],
+            'exactMatch': False
+        }
+        result: dict = FilterConsumer().apply_filters(text_data_8)
+        self.assertEqual(result['imageResults'], [2])
 
     def test_typical_case_9(self):
         # Should return 3
-        text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [9]}
-        image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['imageResults'], [3])
+        text_data_9: dict = {
+            'type': 'activeFilters',
+            'activeFilters': [9],
+            'exactMatch': False
+        }
+        result: dict = FilterConsumer().apply_filters(text_data_9)
+        self.assertEqual(result['imageResults'], [3])
 
     def test_typical_case_10(self):
         # Should return none
-        text_data_1: dict = {'type': 'activeFilters', 'activeFilters': [10]}
-        image_result_data: dict = FilterConsumer.apply_filters(text_data_1)
-        self.assertEqual(image_result_data['imageResults'], [])
+        text_data_10: dict = {
+            'type': 'activeFilters',
+            'activeFilters': [10],
+            'exactMatch': False
+        }
+        result: dict = FilterConsumer().apply_filters(text_data_10)
+        self.assertEqual(result['imageResults'], [])
 
 
 class TestAddTag(TestSocketConsumer):


### PR DESCRIPTION
Adding a toggle that requires results to match the selected tags, and ONLY the selected tags.  For instance, given tags A, B, C, D and E, when "Exact Match" is not activated, selecting filters A and B will return all results that have both tags A and B, including those that also have C, D and E; when "Exact Match" is activated and filters A and B are selected, the results shown will have ONLY tags A and B, NOT C, D or E.  Additionally, if no filters are selected when "Exact Match" is activated, the results will be those images with no tags assigned at all.

Closes #175.