### PR TITLE
deps(Django): update Django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ channels-redis==4.2.0
 constantly==23.10.4
 cryptography==44.0.1
 daphne==4.1.2
-Django==5.0.11
+Django==5.1.7
 djangorestframework==3.15.2
 filetype==1.2.0
 hyperlink==21.0.0


### PR DESCRIPTION
Dependabot identified a vulnerability found in Django 5.0.11 that was previously in use; Django 5.1.7 addresses this vulnerability and is compatible with this project.  Bumping version to 5.1.7.